### PR TITLE
Log caught errors and update README with correct options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@
 3. Add tests to your `.tape.js` file:
    ```js
    module.exports = {
-     'postcss-my-plugin': {
-       'basic': {
-         message: 'supports basic usage'
-       }
+     'basic': {
+       message: 'supports basic usage'
      }
    };
    ```
@@ -125,7 +123,7 @@ An identifying feature of an error expected to be thrown by the test.
 ```js
 {
   'some-test': {
-    error: {
+    errors: {
       message: 'You should not have done that'
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,8 @@ getOptions().then(
 	() => {
 		process.exit(0);
 	},
-	() => {
+	(error) => {
+		console.error(error);
 		process.exit(1);
 	}
 )


### PR DESCRIPTION
Ran into some issues when I updated from version 2. Looking at the README I thought I was using the correct options, but after some debugging and looking at tests I realized the README is wrong.

This PR updates the README as well as adds a `console.error` log so any caught errors are reported to the user instead of just exiting.